### PR TITLE
Use git tags instead of a VERSION file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         ref: ${{ inputs.develop-branch }}
     - name: Grab current version
       id: current-version
-      run: echo "current-version=$(cat VERSION)" >> $GITHUB_OUTPUT
+      run: echo "current-version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
       shell: bash
     - name: Prepare release request
       id: release


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The release automation keeps track of the latest version number using a VERSION file at the root of our projects. It may be possible to find out the information via git tags.
