### PR TITLE
fix: use npm ci instead of npm install in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install
+      - run: npm ci
       - run: npm run all
   test: # make sure the action works on a clean machine without building
     permissions:


### PR DESCRIPTION
## Security fix

### VAST-1109 - Use of `npm install` instead of `npm ci`
Replaces `npm install` with `npm ci` in `.github/workflows/test.yml` to ensure reproducible and secure dependency installation from the lockfile.