### PR TITLE
fix: bump picomatch to 4.0.4 to address method injection vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5517,7 +5517,7 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://artifacts.is.adyen.com/artifactory/api/npm/frontend-npm-virtual/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5516,11 +5516,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "4.0.4",
+      "resolved": "https://artifacts.is.adyen.com/artifactory/api/npm/frontend-npm-virtual/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "typescript": "^5.2.2"
   },
   "overrides": {
-    "undici": "^6.24.0"
+    "undici": "^6.24.0",
+    "picomatch": ">=2.3.2"
   }
 }


### PR DESCRIPTION
## Security fix

### VAST-1700 - Picomatch Method Injection
Bumps `picomatch` to `>=2.3.2` (resolved to 4.0.4) via `overrides` in `package.json`.
The vulnerability (CVE GHSA-3v7f-55p6-f55p) allows method injection in POSIX character classes causing incorrect glob matching. Fixed in 2.3.2+.